### PR TITLE
Implement client credential authentication to config API

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,26 @@
+.access-token-submit {
+  font-weight: bold;
+}
+
+.access-token-submit:hover {
+  color: #99dd77;
+}
+
+.access-token-submit-disabled {
+  display: inline-block;
+  padding: 2px 12px;
+
+  border: 1px solid #dcdcdc;
+  border-radius: 6px;
+  box-shadow: inset 0px 1px 0px 0px #f0f0f0;
+  background: linear-gradient(to bottom, #f6f6f6 5%, #eaeaea 100%);
+  background-color: #f6f6f6;
+
+  color: #a0a0a0;
+  font-family: arial;
+  font-weight: bold;
+  text-decoration: none;
+  text-shadow: 0px 1px 0px #ffffff;
+  cursor: pointer;
+  opacity: 0.7;
+}

--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -1,0 +1,15 @@
+class AccessTokensController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    current_user.create_access_token!
+
+    redirect_back fallback_location: root_path, notice: "Access token was successfully created."
+  end
+
+  def destroy
+    current_user.access_token.destroy
+
+    redirect_back fallback_location: root_path, notice: 'Access token was successfully deleted.'
+  end
+end

--- a/app/controllers/api/v1/configs_controller.rb
+++ b/app/controllers/api/v1/configs_controller.rb
@@ -2,11 +2,11 @@ class Api::V1::ConfigsController < ApplicationController
   skip_before_action :verify_authenticity_token
   before_action :authenticate_access_token, only: %i[create update destroy]
 
-  rescue_from StandardError, with: :handle_standard_error
-  rescue_from ActiveRecord::RecordInvalid, with: :record_invalid
-  rescue_from ActiveRecord::RecordNotUnique, with: :record_already_exists
-  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
-  rescue_from ActionDispatch::Http::Parameters::ParseError, with: :parse_error
+  rescue_from StandardError, with: :render_standard_error
+  rescue_from ActiveRecord::RecordInvalid, with: :render_record_invalid_error
+  rescue_from ActiveRecord::RecordNotUnique, with: :render_record_already_exists_error
+  rescue_from ActiveRecord::RecordNotFound, with: :render_record_not_found_error
+  rescue_from ActionDispatch::Http::Parameters::ParseError, with: :render_parse_error
 
   # GET api/v1/configs/name
   def show
@@ -64,11 +64,6 @@ class Api::V1::ConfigsController < ApplicationController
     end
   end
 
-  def render_token_invalid_error
-    render json: { error: "The access token is missing or invalid." }, status: :unauthorized
-    response.headers['WWW-Authenticate'] = 'Bearer'
-  end
-
   def current_config
     current_user.configs.friendly.find(params[:name])
   end
@@ -83,23 +78,28 @@ class Api::V1::ConfigsController < ApplicationController
     config
   end
 
-  def handle_standard_error(e)
+  def render_standard_error(e)
     render json: { error: e.message }, status: :internal_server_error
   end
 
-  def record_invalid(e)
+  def render_token_invalid_error
+    render json: { error: "The access token is missing or invalid." }, status: :unauthorized
+    response.headers['WWW-Authenticate'] = 'Bearer'
+  end
+
+  def render_record_invalid_error(e)
     render json: { error: e.message }, status: :unprocessable_entity
   end
 
-  def record_already_exists
+  def render_record_already_exists_error
     render json: { error: "#{params[:name]} has already been taken." }, status: :conflict
   end
 
-  def record_not_found
+  def render_record_not_found_error
     render json: { error: "Could not find the config #{params[:name]}" }, status: :not_found
   end
 
-  def parse_error
+  def render_parse_error
     render json: { error: 'Invalid JSON format.' }, status: :bad_request
   end
 

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,0 +1,3 @@
+class AccessToken < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,3 +1,10 @@
 class AccessToken < ApplicationRecord
   belongs_to :user
+  before_create :generate_token
+
+  private
+
+  def generate_token
+    self.token = SecureRandom.hex(16)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
 	has_many :configs, dependent: :destroy
+	has_one :access_token, dependent: :destroy
 
 	include FriendlyId
 	friendly_id :email

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
 <head>
 	<title>Textae Configuration Repository</title>
 	<%= stylesheet_link_tag    'application', media: 'all' %>
+	<script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.11/dist/clipboard.min.js"></script>
 	<%= javascript_include_tag 'application' %>
 	<%= csrf_meta_tags %>
 </head>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -45,3 +45,34 @@
 	</div>
 
 </section>
+
+<% if @user == current_user %>
+	<section>
+		<h2>
+			<span class="heading">Access Tokens</span>
+			<% if @user.access_token.present? %>
+				<button class='access-token-submit-disabled' disabled>create</button>
+			<% else %>
+				<%= form_with url: access_tokens_path, method: :post, html: { style: 'display: inline-block;' } do |form| %>
+					<%= form.submit 'create', class: 'button access-token-submit' %>
+				<% end %>
+			<% end %>
+		</h2>
+
+		<% if @user.access_token.present? %>
+			<table>
+				<tr>
+					<th>Access Token</th>
+					<td id="access-token" style="font-weight: small"><%= @user.access_token.token %></td>
+					<td><button id="clipboard-btn" style="cursor: pointer" data-clipboard-target="#access-token"><%= fa_icon('copy') %></button></td>
+					<td><%= link_to fa_icon('trash'), access_token_path(@user.access_token), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+				</tr>
+			</table>
+		<% end %>
+		</div>
+	</section>
+<% end %>
+
+<script>
+	new ClipboardJS('#clipboard-btn')
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
 	devise_for :users, :controllers => { :omniauth_callbacks => "callbacks" }
+	resources :access_tokens, only: %i[create destroy]
 
 	get '/users/:email' => 'users#show', :constraints => { :email => /.+@.+\..*/ }, as: 'user'
 	post '/configs/:id', to: 'configs#update'

--- a/db/migrate/20241204004344_create_access_tokens.rb
+++ b/db/migrate/20241204004344_create_access_tokens.rb
@@ -1,0 +1,10 @@
+class CreateAccessTokens < ActiveRecord::Migration[7.0]
+  def change
+    create_table :access_tokens do |t|
+      t.string :token, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2017_06_09_020805) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_04_004344) do
+  create_table "access_tokens", force: :cascade do |t|
+    t.string "token", null: false
+    t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_access_tokens_on_user_id"
+  end
+
   create_table "configs", force: :cascade do |t|
     t.string "name"
     t.text "description"
@@ -46,4 +54,5 @@ ActiveRecord::Schema[7.0].define(version: 2017_06_09_020805) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "access_tokens", "users"
 end

--- a/test/controllers/api/v1/configs_controller_test.rb
+++ b/test/controllers/api/v1/configs_controller_test.rb
@@ -4,8 +4,9 @@ class Api::V1::ConfigsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   setup do
-    @user = users(:one)
-    sign_in @user
+    user = users(:one)
+    user.create_access_token!
+    @access_token = user.access_token.token
     @config = configs(:two)
   end
 
@@ -13,7 +14,8 @@ class Api::V1::ConfigsControllerTest < ActionDispatch::IntegrationTest
   test "POST_should_create_config" do
     assert_difference("Config.count", 1) do
       post "/api/v1/configs/test-config", params: '{}',
-                                          headers: { 'Content-Type': 'application/json' }
+                                          headers: { 'Content-Type' => 'application/json',
+                                                     'Authorization' => "Bearer #{@access_token}" }
     end
 
     assert_response 201
@@ -22,14 +24,16 @@ class Api::V1::ConfigsControllerTest < ActionDispatch::IntegrationTest
 
   test "POST_should_save_body_without_format" do
     post "/api/v1/configs/test-config", params: '{ "attribute types": "value" }',
-                                        headers: { 'Content-Type': 'application/json' }
+                                        headers: { 'Content-Type' => 'application/json',
+                                                   'Authorization' => "Bearer #{@access_token}" }
 
     assert_equal JSON.generate({ "attribute types": "value" }), Config.last.body
   end
 
   test "POST_should_save_attributes_with_query_parameter" do
     post "/api/v1/configs/test-config\?description\=abc\&is_public\=true", params: '{}',
-                                                                           headers: { 'Content-Type': 'application/json' }
+                                                                           headers: { 'Content-Type' => 'application/json',
+                                                                                      'Authorization' => "Bearer #{@access_token}" }
 
     assert_equal "abc", Config.last.description
     assert_equal true, Config.last.is_public
@@ -53,7 +57,8 @@ class Api::V1::ConfigsControllerTest < ActionDispatch::IntegrationTest
   # Test PUT/PATCH api/v1/configs/name
   test "PUT_should_update_config" do
     put "/api/v1/configs/#{@config.name}", params: '{ "attribute types": "new_value" }',
-                                           headers: { 'Content-Type': 'application/json' }
+                                           headers: { 'Content-Type' => 'application/json',
+                                                      'Authorization' => "Bearer #{@access_token}" }
 
     assert_response 200
     assert_equal "Config #{@config.name} was successfully updated.", JSON.parse(response.body)['message']
@@ -62,7 +67,7 @@ class Api::V1::ConfigsControllerTest < ActionDispatch::IntegrationTest
 
   test "UPDATE_should_update_attributes_with_query_parameter" do
 
-    put "/api/v1/configs/#{@config.name}\?description\=def\&is_public\=true", headers: { 'Content-Type': 'application/json' }
+    put "/api/v1/configs/#{@config.name}\?description\=def\&is_public\=true", headers: { 'Authorization' => "Bearer #{@access_token}" }
 
     assert_equal "def", Config.friendly.find(@config.name).description
     assert_equal true , Config.friendly.find(@config.name).is_public
@@ -71,7 +76,7 @@ class Api::V1::ConfigsControllerTest < ActionDispatch::IntegrationTest
   # Test DELETE api/v1/configs/name
   test "DELETE_should_delete_config" do
     assert_difference("Config.count", -1) do
-      delete "/api/v1/configs/#{@config.name}"
+      delete "/api/v1/configs/#{@config.name}", headers: { 'Authorization' => "Bearer #{@access_token}" }
     end
 
     assert_response 200
@@ -81,7 +86,8 @@ class Api::V1::ConfigsControllerTest < ActionDispatch::IntegrationTest
   # Test exceptions
   test "should_return_400_when_request_json_is_invalid_format" do
     post "/api/v1/configs/invalid-config", params: 'invalid json',
-                                           headers: { 'Content-Type': 'application/json' }
+                                           headers: { 'Content-Type' => 'application/json',
+                                                      'Authorization' => "Bearer #{@access_token}" }
 
     assert_response 400
     assert_equal "Invalid JSON format.", JSON.parse(response.body)['error']
@@ -94,25 +100,28 @@ class Api::V1::ConfigsControllerTest < ActionDispatch::IntegrationTest
     assert_response 404
     assert_equal expected_message, JSON.parse(response.body)['error']
 
-    put "/api/v1/configs/non-existent-config", params: '{}', headers: { 'Content-Type': 'application/json' }
+    put "/api/v1/configs/non-existent-config", params: '{}', headers: { 'Content-Type': 'application/json',
+                                                                        'Authorization' => "Bearer #{@access_token}" }
     assert_response 404
     assert_equal expected_message, JSON.parse(response.body)['error']
 
-    delete "/api/v1/configs/non-existent-config"
+    delete "/api/v1/configs/non-existent-config", headers: { 'Authorization' => "Bearer #{@access_token}" }
     assert_response 404
     assert_equal expected_message, JSON.parse(response.body)['error']
   end
 
   test "should_return_409_when_config_is_already_exists" do
     post "/api/v1/configs/#{@config.name}", params: '{ "attribute types": "value" }',
-                                            headers: { 'Content-Type': 'application/json' }
+                                            headers: { 'Content-Type': 'application/json',
+                                                       'Authorization' => "Bearer #{@access_token}" }
 
     assert_response 409
     assert_equal "#{@config.name} has already been taken.", JSON.parse(response.body)['error']
   end
 
   test "should_return_422_when_request_body_is_not_present" do
-    post "/api/v1/configs/test-config"
+    post "/api/v1/configs/test-config", headers: { 'Content-Type': 'application/json',
+                                                   'Authorization' => "Bearer #{@access_token}" }
 
     assert_response 422
     assert_equal "Validation failed: Body can't be blank", JSON.parse(response.body)['error']
@@ -120,14 +129,16 @@ class Api::V1::ConfigsControllerTest < ActionDispatch::IntegrationTest
 
   test "should_return_422_when_config_name_is_invalid" do
     post "/api/v1/configs/abc@def", params: '{}',
-                                    headers: { 'Content-Type': 'application/json' }
+                                    headers: { 'Content-Type': 'application/json',
+                                               'Authorization' => "Bearer #{@access_token}" }
 
     assert_response 422
   end
 
   test "should_return_422_when_is_public_is_not_boolean" do
     post "/api/v1/configs/test-config\?is_public\=abc", params: '{}',
-                                                        headers: { 'Content-Type': 'application/json' }
+                                                        headers: { 'Content-Type': 'application/json',
+                                                                   'Authorization' => "Bearer #{@access_token}" }
 
     assert_response 422
   end

--- a/test/controllers/api/v1/configs_controller_test.rb
+++ b/test/controllers/api/v1/configs_controller_test.rb
@@ -166,9 +166,9 @@ class Api::V1::ConfigsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should_not_be_able_to_change_other_users_resources" do
-    put "/api/v1/configs/#{@config.name}", params: '{ "attribute types": "new_value" }',
-                                           headers: { 'Content-Type' => 'application/json',
-                                                      'Authorization' => "Bearer #{@access_token}" }
+    put "/api/v1/configs/#{@other_user_config.name}", params: '{ "attribute types": "new_value" }',
+                                                      headers: { 'Content-Type' => 'application/json',
+                                                                  'Authorization' => "Bearer #{@access_token}" }
     assert_response 404
 
     delete "/api/v1/configs/#{@other_user_config.name}", headers: { 'Authorization' => "Bearer #{@access_token}" }

--- a/test/controllers/api/v1/configs_controller_test.rb
+++ b/test/controllers/api/v1/configs_controller_test.rb
@@ -8,6 +8,7 @@ class Api::V1::ConfigsControllerTest < ActionDispatch::IntegrationTest
     user.create_access_token!
     @access_token = user.access_token.token
     @config = configs(:two)
+    @other_user_config = configs(:three)
   end
 
   # Test POST api/v1/configs/name
@@ -141,5 +142,36 @@ class Api::V1::ConfigsControllerTest < ActionDispatch::IntegrationTest
                                                                    'Authorization' => "Bearer #{@access_token}" }
 
     assert_response 422
+  end
+
+  # Test authentication
+  test "should_not_be_able_to_change_resources_without_access_token" do
+    post "/api/v1/configs/test-config", params: '{ "attribute types": "value" }',
+                                        headers: { 'Content-Type' => 'application/json' }
+    assert_response 401
+
+    put "/api/v1/configs/#{@config.name}", params: '{ "attribute types": "new_value" }',
+                                           headers: { 'Content-Type' => 'application/json' }
+    assert_response 401
+
+    delete "/api/v1/configs/#{@config.name}"
+    assert_response 401
+  end
+
+  test "should_not_be_able_to_change_resources_with_invalid_access_token" do
+    post "/api/v1/configs/test-config", params: '{ "attribute types": "value" }',
+                                        headers: { 'Content-Type' => 'application/json',
+                                                   'Authorization' => "Bearer invalid-token" }
+    assert_response 401
+  end
+
+  test "should_not_be_able_to_change_other_users_resources" do
+    put "/api/v1/configs/#{@config.name}", params: '{ "attribute types": "new_value" }',
+                                           headers: { 'Content-Type' => 'application/json',
+                                                      'Authorization' => "Bearer #{@access_token}" }
+    assert_response 404
+
+    delete "/api/v1/configs/#{@other_user_config.name}", headers: { 'Authorization' => "Bearer #{@access_token}" }
+    assert_response 404
   end
 end

--- a/test/fixtures/configs.yml
+++ b/test/fixtures/configs.yml
@@ -11,3 +11,9 @@ two:
   body: '{}'
   is_public: true
   user_id: 1
+
+three:
+  name: test-config-2
+  body: '{}'
+  is_public: true
+  user_id: 2


### PR DESCRIPTION
Closes: #12

## 概要
config APIにClient Credential認証を実装しました。

## 作業内容
- アクセストークン用のModel, Controllerを作成
- ユーザー詳細ページにトークン生成欄を追加
  - コピーボタン追加のためにClipboardJSをCDNで導入
- config APIのPOST/PUT/DELETEにトークン認証機能を追加
- 認証追加によって失敗するテストの修正
- 認証テストの追加

## 画面の確認
### 生成前
|<img width="1102" alt="image" src="https://github.com/user-attachments/assets/6f657e89-fb78-441c-b569-c4d7508528d8">|
|:-|

### 生成後
PubDictionaries等と同様に、生成後はボタン押下不可・コピー・削除が可能です。
|<img width="1117" alt="image" src="https://github.com/user-attachments/assets/cf4e1572-6c33-4b60-babd-46846736e03b">|
|:-|

### 自分以外のユーザーページにはトークン生成欄が表示されない
|<img width="1056" alt="image" src="https://github.com/user-attachments/assets/9cd4a256-6937-4af6-8bcc-e7cfbc166cb7">|
|:-|

## 機能の確認
自動テストで以下の点について確認しました。
- POST, PUT, DELETEでトークンを添付するとリソース変更ができること
- POST, PUT, DELETEでトークンを添付しないとリソース変更ができず401が返ること
- トークンが不正な場合401が返ること
- 認証が通っても他のユーザーのリソースは変更できないこと

### テスト結果
1つredが出ていますが期待通りのエラーで、以下のPRで修正中です。
https://github.com/pubannotation/textae-configs/pull/18

その他のテストは全て通りました。
```
# Running:

.......F

Failure:
Api::V1::ConfigsControllerTest#test_should_return_422_when_is_public_is_not_boolean [test/controllers/api/v1/configs_controller_test.rb:144]:
Expected response to be a <422: Unprocessable Entity>, but was a <201: Created>
Response body: {"message":"Config test-config was successfully created.","show_instruction":"If you want to see the saved body, send a GET request to /api/v1/configs/test-config"}.
Expected: 422
  Actual: 201


rails test test/controllers/api/v1/configs_controller_test.rb:139

.........

Finished in 0.123084s, 138.1171 runs/s, 300.6077 assertions/s.
17 runs, 37 assertions, 1 failures, 0 errors, 0 skips
```