### PR TITLE
Refactor JSON handling and logic move

### DIFF
--- a/app/controllers/api/v1/configs_controller.rb
+++ b/app/controllers/api/v1/configs_controller.rb
@@ -10,8 +10,9 @@ class Api::V1::ConfigsController < ApplicationController
   # GET api/v1/configs/name
   def show
     config = Config.friendly.find(params[:name])
+    parsed_body = JSON.parse(config.body)
 
-    render json: config.body, status: :ok
+    render json: JSON.pretty_generate(parsed_body), status: :ok
   end
 
   # POST api/v1/configs/name
@@ -57,9 +58,7 @@ class Api::V1::ConfigsController < ApplicationController
 
   def get_body
     raw_body = JSON.parse(request.raw_post)
-    filtered_body = filter_body(raw_body)
-
-    JSON.pretty_generate(filtered_body)
+    filter_body(raw_body)
   end
 
   def filter_body(target)

--- a/app/controllers/api/v1/configs_controller.rb
+++ b/app/controllers/api/v1/configs_controller.rb
@@ -48,7 +48,7 @@ class Api::V1::ConfigsController < ApplicationController
   def new_config
     config = {}
     config[:name] = params[:name]
-    config[:body] = Config.parse_body(request.raw_post) if request.raw_post.present?
+    config[:body] = Config.format_body(request.raw_post) if request.raw_post.present?
     config[:description] = params[:description] if params[:description]
     config[:is_public] = params[:is_public] if params[:is_public]
 

--- a/app/controllers/api/v1/configs_controller.rb
+++ b/app/controllers/api/v1/configs_controller.rb
@@ -58,18 +58,7 @@ class Api::V1::ConfigsController < ApplicationController
 
   def get_body
     raw_body = JSON.parse(request.raw_post)
-    filter_body(raw_body)
-  end
-
-  def filter_body(target)
-    target.slice(
-      "autocompletion_ws",
-      "entity types",
-      "relation types",
-      "attribute types",
-      "delimiter characters",
-      "non-edge characters"
-    ).transform_values(&:presence).compact
+    Config.filter_body(raw_body)
   end
 
   def handle_standard_error(e)

--- a/app/controllers/api/v1/configs_controller.rb
+++ b/app/controllers/api/v1/configs_controller.rb
@@ -10,9 +10,8 @@ class Api::V1::ConfigsController < ApplicationController
   # GET api/v1/configs/name
   def show
     config = Config.friendly.find(params[:name])
-    parsed_body = JSON.parse(config.body)
 
-    render json: JSON.pretty_generate(parsed_body), status: :ok
+    render json: config.pretty_body, status: :ok
   end
 
   # POST api/v1/configs/name

--- a/app/controllers/api/v1/configs_controller.rb
+++ b/app/controllers/api/v1/configs_controller.rb
@@ -48,16 +48,11 @@ class Api::V1::ConfigsController < ApplicationController
   def new_config
     config = {}
     config[:name] = params[:name]
-    config[:body] = get_body if request.raw_post.present?
+    config[:body] = Config.parse_body(request.raw_post) if request.raw_post.present?
     config[:description] = params[:description] if params[:description]
     config[:is_public] = params[:is_public] if params[:is_public]
 
     config
-  end
-
-  def get_body
-    raw_body = JSON.parse(request.raw_post)
-    Config.filter_body(raw_body)
   end
 
   def handle_standard_error(e)

--- a/app/controllers/configs_controller.rb
+++ b/app/controllers/configs_controller.rb
@@ -13,8 +13,7 @@ class ConfigsController < ApplicationController
 	# GET /configs/1
 	# GET /configs/1.json
 	def show
-		parsed_body = JSON.parse(@config.body)
-		@formatted_body = JSON.pretty_generate(parsed_body)
+		@formatted_body = @config.pretty_body
 
 		respond_to do |format|
 			format.html

--- a/app/controllers/configs_controller.rb
+++ b/app/controllers/configs_controller.rb
@@ -13,9 +13,12 @@ class ConfigsController < ApplicationController
 	# GET /configs/1
 	# GET /configs/1.json
 	def show
+		parsed_body = JSON.parse(@config.body)
+		@formatted_body = JSON.pretty_generate(parsed_body)
+
 		respond_to do |format|
 			format.html
-			format.json { render json: @config.body }
+			format.json { render json: @formatted_body }
 		end
 	end
 
@@ -86,7 +89,7 @@ class ConfigsController < ApplicationController
 		end
 
 		def get_body
-			body_obj = if params.has_key?(:config) && params[:config].present?
+			if params.has_key?(:config) && params[:config].present?
 				_config = params.require(:config).permit(:name, :description, :body, :is_public)
 				if _config[:body].present?
 					begin
@@ -110,8 +113,6 @@ class ConfigsController < ApplicationController
 			else
 				nil
 			end
-
-			body_obj.nil? ? nil : JSON.pretty_generate(body_obj)
 		end
 
 		def get_config

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -17,8 +17,10 @@ class Config < ApplicationRecord
 		end
 	}
 
-	def self.filter_body(target)
-		target.slice(
+	def self.parse_body(raw_body)
+		parsed_body = JSON.parse(raw_body)
+
+		parsed_body.slice(
 			"autocompletion_ws",
 			"entity types",
 			"relation types",

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -1,6 +1,8 @@
 class Config < ApplicationRecord
 	belongs_to :user, optional: true
 
+	before_save :generate_json_body
+
 	include FriendlyId
 	friendly_id :name
 
@@ -15,4 +17,12 @@ class Config < ApplicationRecord
 		end
 	}
 
+	private
+
+	def generate_json_body
+		# body is saved in ruby format through controller.
+		# To save as JSON, convert format using gsub.
+		parsed_body = JSON.parse(body.gsub('=>', ':'))
+		self.body = JSON.generate(parsed_body)
+	end
 end

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -17,6 +17,17 @@ class Config < ApplicationRecord
 		end
 	}
 
+	def self.filter_body(target)
+		target.slice(
+			"autocompletion_ws",
+			"entity types",
+			"relation types",
+			"attribute types",
+			"delimiter characters",
+			"non-edge characters"
+		).transform_values(&:presence).compact
+	end
+
 	private
 
 	def generate_json_body

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -1,8 +1,6 @@
 class Config < ApplicationRecord
 	belongs_to :user, optional: true
 
-	before_save :generate_json_body
-
 	include FriendlyId
 	friendly_id :name
 
@@ -17,10 +15,10 @@ class Config < ApplicationRecord
 		end
 	}
 
-	def self.parse_body(raw_body)
+	def self.format_body(raw_body)
 		parsed_body = JSON.parse(raw_body)
 
-		parsed_body.slice(
+		filtered_body = parsed_body.slice(
 			"autocompletion_ws",
 			"entity types",
 			"relation types",
@@ -28,19 +26,12 @@ class Config < ApplicationRecord
 			"delimiter characters",
 			"non-edge characters"
 		).transform_values(&:presence).compact
+
+		JSON.generate(filtered_body)
 	end
 
 	def pretty_body
 		parsed_body = JSON.parse(body)
 		JSON.pretty_generate(parsed_body)
-	end
-
-	private
-
-	def generate_json_body
-		# body is saved in ruby format through controller.
-		# To save as JSON, convert format using gsub.
-		parsed_body = JSON.parse(body.gsub('=>', ':'))
-		self.body = JSON.generate(parsed_body)
 	end
 end

--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -28,6 +28,11 @@ class Config < ApplicationRecord
 		).transform_values(&:presence).compact
 	end
 
+	def pretty_body
+		parsed_body = JSON.parse(body)
+		JSON.pretty_generate(parsed_body)
+	end
+
 	private
 
 	def generate_json_body

--- a/app/views/configs/show.html.erb
+++ b/app/views/configs/show.html.erb
@@ -37,7 +37,7 @@
 	<tr>
 		<th>Body</th>
 		<td>
-	<pre><%= @config.body %></pre>
+	<pre><%= @formatted_body %></pre>
 		</td>
 	</tr>
 </table>


### PR DESCRIPTION
## 概要
bodyデータの扱いの改善と、コントローラーのロジック移動を行いました。

## 作業内容
- config.bodyをpretty_generateを用いてフォーマットして保存する形から、保存時にはフォーマットしないように変更
  - 上記変更に伴い、画面・APIでbodyを参照するタイミングでフォーマットするように変更
- api/v1/configs_controllerのロジックをモデルに移動


## 動作確認
### ブラウザ
フォーマットしてない形で保存します。
|<img width="1042" alt="image" src="https://github.com/user-attachments/assets/c4dbb44d-3eed-4e69-b526-44659a7a7969">|
|:-|

保存後にフォーマットされて表示されています。
|<img width="621" alt="image" src="https://github.com/user-attachments/assets/7e2ee171-d1ac-4de9-95ec-11ad821ea2bb">|
|:-|

### API
同じくフォーマットしていないbodyを渡します。
```
curl -X POST http://localhost:3000/api/v1/configs/test2\?description\=abc\&is_public\=true \
-H "Content-Type: application/json" \
-d '{"entity types":[{"id":"NP","color":"#AAAAFE","default":true}],"relation types":[{"id":"coref-ident","color":"#0000FF","default":true},{"id":"coref-pron","color":"#00AA00"},{"id":"coref-relat","color":"#00AA00"},{"id":"coref-appos","color":"#0000FF"},{"id":"whole-part","color":"#00FFFF"},{"id":"part-whole","color":"#00FFFF"},{"id":"coref-other","color":"#888888"},{"id":"coref-xxx","color":"#FF0000"}]}'
{"message":"Config test2 was successfully created.","show_instruction":"If you want to see the saved body, send a GET request to /api/v1/configs/test2"}
```

GETで参照するとフォーマットされて表示されます。
```
curl -X GET http://localhost:3000/api/v1/configs/test2
{
  "entity types": [
    {
      "id": "NP",
      "color": "#AAAAFE",
      "default": true
    }
  ],
  "relation types": [
    {
      "id": "coref-ident",
      "color": "#0000FF",
      "default": true
    },
    {
      "id": "coref-pron",
      "color": "#00AA00"
    },
    {
      "id": "coref-relat",
      "color": "#00AA00"
    },
    {
      "id": "coref-appos",
      "color": "#0000FF"
    },
    {
      "id": "whole-part",
      "color": "#00FFFF"
    },
    {
      "id": "part-whole",
      "color": "#00FFFF"
    },
    {
      "id": "coref-other",
      "color": "#888888"
    },
    {
      "id": "coref-xxx",
      "color": "#FF0000"
    }
  ]
}%
```

## データ保存形式による変更前のデータへの影響について
保存形式変更前・変更後のデータがどちらも期待するフォーマットで表示されるか確認しました。

以下の4パターンでデータを保存しておき、動作を確認しました。
- 変更前：prettyしないフォーマットで保存
- 変更前：prettyフォーマットで保存
- 変更後：prettyしないフォーマットで保存
- 変更後：prettyフォーマットで保存
<details>
<summary>データ</summary>

```
irb(main):001:0> Config.all
  Config Load (0.5ms)  SELECT "configs".* FROM "configs"
=>
[#<Config:0x0000000106035500
  id: 103,
  name: "before-change-pretty",
  description: "",
  body:
   "{\n  \"entity types\": [\n    {\n      \"id\": \"NP\",\n      \"color\": \"#AAAAFE\",\n      \"default\": true\n    }\n  ],\n  \"relation types\": [\n    {\n      \"id\": \"coref-ident\",\n      \"color\": \"#0000FF\",\n      \"default\": true\n    },\n    {\n      \"id\": \"coref-pron\",\n      \"color\": \"#00AA00\"\n    },\n    {\n      \"id\": \"coref-relat\",\n      \"color\": \"#00AA00\"\n    },\n    {\n      \"id\": \"coref-appos\",\n      \"color\": \"#0000FF\"\n    },\n    {\n      \"id\": \"whole-part\",\n      \"color\": \"#00FFFF\"\n    },\n    {\n      \"id\": \"part-whole\",\n      \"color\": \"#00FFFF\"\n    },\n    {\n      \"id\": \"coref-other\",\n      \"color\": \"#888888\"\n    },\n    {\n      \"id\": \"coref-xxx\",\n      \"color\": \"#FF0000\"\n    }\n  ]\n}",
  is_public: true,
  created_at: Mon, 09 Dec 2024 01:00:26.302021000 UTC +00:00,
  updated_at: Mon, 09 Dec 2024 01:08:47.327203000 UTC +00:00,
  user_id: 1>,
 #<Config:0x00000001064f4938
  id: 104,
  name: "before-change-no-pretty",
  description: "",
  body:
   "{\n  \"entity types\": [\n    {\n      \"id\": \"NP\",\n      \"color\": \"#AAAAFE\",\n      \"default\": true\n    }\n  ],\n  \"relation types\": [\n    {\n      \"id\": \"coref-ident\",\n      \"color\": \"#0000FF\",\n      \"default\": true\n    },\n    {\n      \"id\": \"coref-pron\",\n      \"color\": \"#00AA00\"\n    },\n    {\n      \"id\": \"coref-relat\",\n      \"color\": \"#00AA00\"\n    },\n    {\n      \"id\": \"coref-appos\",\n      \"color\": \"#0000FF\"\n    },\n    {\n      \"id\": \"whole-part\",\n      \"color\": \"#00FFFF\"\n    },\n    {\n      \"id\": \"part-whole\",\n      \"color\": \"#00FFFF\"\n    },\n    {\n      \"id\": \"coref-other\",\n      \"color\": \"#888888\"\n    },\n    {\n      \"id\": \"coref-xxx\",\n      \"color\": \"#FF0000\"\n    }\n  ]\n}",
  is_public: true,
  created_at: Mon, 09 Dec 2024 01:01:36.907970000 UTC +00:00,
  updated_at: Mon, 09 Dec 2024 01:01:36.907970000 UTC +00:00,
  user_id: 1>,
 #<Config:0x00000001064f4898
  id: 105,
  name: "after-change-no-pretty",
  description: "",
  body:
   "{\"entity types\":[{\"id\":\"NP\",\"color\":\"#AAAAFE\",\"default\":true}],\"relation types\":[{\"id\":\"coref-ident\",\"color\":\"#0000FF\",\"default\":true},{\"id\":\"coref-pron\",\"color\":\"#00AA00\"},{\"id\":\"coref-relat\",\"color\":\"#00AA00\"},{\"id\":\"coref-appos\",\"color\":\"#0000FF\"},{\"id\":\"whole-part\",\"color\":\"#00FFFF\"},{\"id\":\"part-whole\",\"color\":\"#00FFFF\"},{\"id\":\"coref-other\",\"color\":\"#888888\"},{\"id\":\"coref-xxx\",\"color\":\"#FF0000\"}]}",
  is_public: true,
  created_at: Mon, 09 Dec 2024 01:04:08.744771000 UTC +00:00,
  updated_at: Mon, 09 Dec 2024 01:04:08.744771000 UTC +00:00,
  user_id: 1>,
 #<Config:0x00000001064f47f8
  id: 106,
  name: "after-change-pretty",
  description: "",
  body:
   "{\"entity types\":[{\"id\":\"NP\",\"color\":\"#AAAAFE\",\"default\":true}],\"relation types\":[{\"id\":\"coref-ident\",\"color\":\"#0000FF\",\"default\":true},{\"id\":\"coref-pron\",\"color\":\"#00AA00\"},{\"id\":\"coref-relat\",\"color\":\"#00AA00\"},{\"id\":\"coref-appos\",\"color\":\"#0000FF\"},{\"id\":\"whole-part\",\"color\":\"#00FFFF\"},{\"id\":\"part-whole\",\"color\":\"#00FFFF\"},{\"id\":\"coref-other\",\"color\":\"#888888\"},{\"id\":\"coref-xxx\",\"color\":\"#FF0000\"}]}",
  is_public: false,
  created_at: Mon, 09 Dec 2024 01:04:43.359309000 UTC +00:00,
  updated_at: Mon, 09 Dec 2024 01:04:43.359309000 UTC +00:00,
  user_id: 1>]
```
</details>

### ブラウザ
全てのパターンにおいて表示されるJSONに不整合がない、かつフォーマットされて表示されることを確認しました。

### API
APIについても同様に問題ないことを確認しました。

<details>
<summary>実行結果</summary>

```
➜  textae-configs git:(refactor/json_handling_and_logic_move) ✗ curl -X GET http://localhost:3000/api/v1/configs/before-change-pretty
{
  "entity types": [
    {
      "id": "NP",
      "color": "#AAAAFE",
      "default": true
    }
  ],
  "relation types": [
    {
      "id": "coref-ident",
      "color": "#0000FF",
      "default": true
    },
    {
      "id": "coref-pron",
      "color": "#00AA00"
    },
    {
      "id": "coref-relat",
      "color": "#00AA00"
    },
    {
      "id": "coref-appos",
      "color": "#0000FF"
    },
    {
      "id": "whole-part",
      "color": "#00FFFF"
    },
    {
      "id": "part-whole",
      "color": "#00FFFF"
    },
    {
      "id": "coref-other",
      "color": "#888888"
    },
    {
      "id": "coref-xxx",
      "color": "#FF0000"
    }
  ]
}%
➜  textae-configs git:(refactor/json_handling_and_logic_move) ✗ curl -X GET http://localhost:3000/api/v1/configs/before-change-no-pretty
{
  "entity types": [
    {
      "id": "NP",
      "color": "#AAAAFE",
      "default": true
    }
  ],
  "relation types": [
    {
      "id": "coref-ident",
      "color": "#0000FF",
      "default": true
    },
    {
      "id": "coref-pron",
      "color": "#00AA00"
    },
    {
      "id": "coref-relat",
      "color": "#00AA00"
    },
    {
      "id": "coref-appos",
      "color": "#0000FF"
    },
    {
      "id": "whole-part",
      "color": "#00FFFF"
    },
    {
      "id": "part-whole",
      "color": "#00FFFF"
    },
    {
      "id": "coref-other",
      "color": "#888888"
    },
    {
      "id": "coref-xxx",
      "color": "#FF0000"
    }
  ]
}%
➜  textae-configs git:(refactor/json_handling_and_logic_move) ✗ curl -X GET http://localhost:3000/api/v1/configs/after-change-pretty
{
  "entity types": [
    {
      "id": "NP",
      "color": "#AAAAFE",
      "default": true
    }
  ],
  "relation types": [
    {
      "id": "coref-ident",
      "color": "#0000FF",
      "default": true
    },
    {
      "id": "coref-pron",
      "color": "#00AA00"
    },
    {
      "id": "coref-relat",
      "color": "#00AA00"
    },
    {
      "id": "coref-appos",
      "color": "#0000FF"
    },
    {
      "id": "whole-part",
      "color": "#00FFFF"
    },
    {
      "id": "part-whole",
      "color": "#00FFFF"
    },
    {
      "id": "coref-other",
      "color": "#888888"
    },
    {
      "id": "coref-xxx",
      "color": "#FF0000"
    }
  ]
}%
➜  textae-configs git:(refactor/json_handling_and_logic_move) ✗ curl -X GET http://localhost:3000/api/v1/configs/after-change-no-pretty
{
  "entity types": [
    {
      "id": "NP",
      "color": "#AAAAFE",
      "default": true
    }
  ],
  "relation types": [
    {
      "id": "coref-ident",
      "color": "#0000FF",
      "default": true
    },
    {
      "id": "coref-pron",
      "color": "#00AA00"
    },
    {
      "id": "coref-relat",
      "color": "#00AA00"
    },
    {
      "id": "coref-appos",
      "color": "#0000FF"
    },
    {
      "id": "whole-part",
      "color": "#00FFFF"
    },
    {
      "id": "part-whole",
      "color": "#00FFFF"
    },
    {
      "id": "coref-other",
      "color": "#888888"
    },
    {
      "id": "coref-xxx",
      "color": "#FF0000"
    }
  ]
}%
```
</details>