### PR TITLE
Added config API test

### DIFF
--- a/test/controllers/api/v1/configs_controller_test.rb
+++ b/test/controllers/api/v1/configs_controller_test.rb
@@ -1,0 +1,125 @@
+require 'test_helper'
+
+class Api::V1::ConfigsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user = users(:one)
+    sign_in @user
+    @config = configs(:two)
+  end
+
+  # Test POST api/v1/configs/name
+  test "POST_should_create_config" do
+    assert_difference("Config.count", 1) do
+      post "/api/v1/configs/test-config", params: '{}',
+                                          headers: { 'Content-Type': 'application/json' }
+    end
+
+    assert_response 201
+    assert_equal "Config test-config was successfully created.", JSON.parse(response.body)['message']
+  end
+
+  test "POST_should_save_body_without_format" do
+    post "/api/v1/configs/test-config", params: '{ "attribute types": "value" }',
+                                        headers: { 'Content-Type': 'application/json' }
+
+    assert_equal JSON.generate({ "attribute types": "value" }), Config.last.body
+  end
+
+  test "POST_should_save_attributes_with_query_parameter" do
+    post "/api/v1/configs/test-config\?description\=abc\&is_public\=true", params: '{}',
+                                                                           headers: { 'Content-Type': 'application/json' }
+
+    assert_equal "abc", Config.last.description
+    assert_equal true, Config.last.is_public
+  end
+
+  # Test GET api/v1/configs/name
+  test "GET_should_show_config" do
+    get "/api/v1/configs/#{@config.name}"
+
+    assert response.body
+    assert_response 200
+  end
+
+  test "GET_should_show_formatted_body" do
+    get "/api/v1/configs/#{@config.name}"
+
+    expected_response = JSON.pretty_generate(JSON.parse(@config.body))
+    assert_equal expected_response, response.body
+  end
+
+  # Test PUT/PATCH api/v1/configs/name
+  test "PUT_should_update_config" do
+    put "/api/v1/configs/#{@config.name}", params: '{ "attribute types": "new_value" }',
+                                           headers: { 'Content-Type': 'application/json' }
+
+    assert_response 200
+    assert_equal "Config #{@config.name} was successfully updated.", JSON.parse(response.body)['message']
+    assert_equal JSON.generate({ "attribute types": "new_value" }), Config.friendly.find(@config.name).body
+  end
+
+  test "UPDATE_should_update_attributes_with_query_parameter" do
+
+    put "/api/v1/configs/#{@config.name}\?description\=def\&is_public\=true", headers: { 'Content-Type': 'application/json' }
+
+    assert_equal "def", Config.friendly.find(@config.name).description
+    assert_equal true , Config.friendly.find(@config.name).is_public
+  end
+
+  # Test DELETE api/v1/configs/name
+  test "DELETE_should_delete_config" do
+    assert_difference("Config.count", -1) do
+      delete "/api/v1/configs/#{@config.name}"
+    end
+
+    assert_response 200
+    assert_equal "Config #{@config.name} was successfully deleted.", JSON.parse(response.body)['message']
+  end
+
+  # Test exceptions
+  test "should_return_400_when_request_json_is_invalid_format" do
+    post "/api/v1/configs/invalid-config", params: 'invalid json',
+                                           headers: { 'Content-Type': 'application/json' }
+
+    assert_response 400
+    assert_equal "Invalid JSON format.", JSON.parse(response.body)['error']
+  end
+
+  test "should_return_404_when_config_is_not_found" do
+    get "/api/v1/configs/non-existent-config"
+
+    assert_response 404
+    assert_equal "Could not find the config non-existent-config", JSON.parse(response.body)['error']
+  end
+
+  test "should_return_409_when_config_is_already_exists" do
+    post "/api/v1/configs/#{@config.name}", params: '{ "attribute types": "value" }',
+                                            headers: { 'Content-Type': 'application/json' }
+
+    assert_response 409
+    assert_equal "#{@config.name} has already been taken.", JSON.parse(response.body)['error']
+  end
+
+  test "should_return_422_when_request_body_is_not_present" do
+    post "/api/v1/configs/test-config"
+
+    assert_response 422
+    assert_equal "Validation failed: Body can't be blank", JSON.parse(response.body)['error']
+  end
+
+  test "should_return_422_when_config_name_is_invalid" do
+    post "/api/v1/configs/abc@def", params: '{}',
+                                    headers: { 'Content-Type': 'application/json' }
+
+    assert_response 422
+  end
+
+  test "should_return_422_when_is_public_is_not_boolean" do
+    post "/api/v1/configs/test-config\?is_public\=abc", params: '{}',
+                                                        headers: { 'Content-Type': 'application/json' }
+
+    assert_response 422
+  end
+end

--- a/test/controllers/api/v1/configs_controller_test.rb
+++ b/test/controllers/api/v1/configs_controller_test.rb
@@ -88,10 +88,19 @@ class Api::V1::ConfigsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should_return_404_when_config_is_not_found" do
-    get "/api/v1/configs/non-existent-config"
+    expected_message = "Could not find the config non-existent-config"
 
+    get "/api/v1/configs/non-existent-config"
     assert_response 404
-    assert_equal "Could not find the config non-existent-config", JSON.parse(response.body)['error']
+    assert_equal expected_message, JSON.parse(response.body)['error']
+
+    put "/api/v1/configs/non-existent-config", params: '{}', headers: { 'Content-Type': 'application/json' }
+    assert_response 404
+    assert_equal expected_message, JSON.parse(response.body)['error']
+
+    delete "/api/v1/configs/non-existent-config"
+    assert_response 404
+    assert_equal expected_message, JSON.parse(response.body)['error']
   end
 
   test "should_return_409_when_config_is_already_exists" do

--- a/test/fixtures/configs.yml
+++ b/test/fixtures/configs.yml
@@ -7,7 +7,7 @@ one:
   is_public: false
 
 two:
-  name: MyString
-  description: MyText
-  body: MyText
-  is_public: false
+  name: test-config-1
+  body: '{}'
+  is_public: true
+  user_id: 1

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,8 +4,14 @@
 # model remove the '{}' from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
-# column: value
-#
-two: {}
-#  column: value
+one:
+  id: 1
+  email: "test1@example.com"
+  encrypted_password: "password"
+  confirmed_at: <%= Time.now - 100 %>
+
+two:
+  id: 2
+  email: "test2@example.com"
+  encrypted_password: "password"
+  confirmed_at: <%= Time.now - 100 %>


### PR DESCRIPTION
## 概要
config CRUD APIのテストを追加しました。

## 作業内容
- fixturesの修正
- 基本的な動作と例外処理についてのテストを追加

### fixturesの修正について
現状のfixturesでは、deviseとfriendly_idに適合していない形になっていました。
テストでログインやfriendly_idでエラーが起きないようにfixturesを修正しました。

## テスト結果
```
rails test test/controllers/api/v1/configs_controller_test.rb
/Users/ysh-nh/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/activesupport-7.0.8/lib/active_support/notifications.rb:4: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.
DEPRECATION WARNING: Using legacy connection handling is deprecated. Please set
`legacy_connection_handling` to `false` in your application.

The new connection handling does not support `connection_handlers`
getter and setter.

Read more about how to migrate at: https://guides.rubyonrails.org/active_record_multiple_databases.html#migrate-to-the-new-connection-handling
 (called from <top (required)> at /Users/ysh-nh/develop/textae-configs/app/models/application_record.rb:1)
/Users/ysh-nh/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/activesupport-7.0.8/lib/active_support/testing/parallelization.rb:3: warning: drb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add drb to your Gemfile or gemspec to silence this warning.
Run options: --seed 62159

# Running:

..........F

Failure:
Api::V1::ConfigsControllerTest#test_should_return_422_when_is_public_is_not_boolean [test/controllers/api/v1/configs_controller_test.rb:123]:
Expected response to be a <422: Unprocessable Entity>, but was a <201: Created>
Response body: {"message":"Config test-config was successfully created.","show_instruction":"If you want to see the saved body, send a GET request to /api/v1/configs/test-config"}.
Expected: 422
  Actual: 201


rails test test/controllers/api/v1/configs_controller_test.rb:119

...

Finished in 0.090461s, 154.7628 runs/s, 298.4712 assertions/s.
14 runs, 27 assertions, 1 failures, 0 errors, 0 skips
```

## 既存のテストについて

## test_should_return_422_when_is_public_is_not_booleanについて
クエリパラメータis_publicに適当な値を指定した際に422エラーを返すことを期待するテストです。
現在は作成が通ってしまうのでRedになっています。

以下のPRで修正中の内容です。
https://github.com/pubannotation/textae-configs/pull/18

現状Redになるのは正しいのでそのままとしています。

## 既存のテストについて
既存のテストは全て失敗します。
6年前のプロジェクト開始時のコミットで作られたもののようです。
deviseの導入やMinitestの記法が変わったためエラーが起きている状態になっています。

このPRはconfig APIのテスト作成のため、対応はしませんでした。

<details>
<summary>実行結果</summary>

```
rails test test/controllers/configs_controller_test.rb
/Users/ysh-nh/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/activesupport-7.0.8/lib/active_support/notifications.rb:4: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.
DEPRECATION WARNING: Using legacy connection handling is deprecated. Please set
`legacy_connection_handling` to `false` in your application.

The new connection handling does not support `connection_handlers`
getter and setter.

Read more about how to migrate at: https://guides.rubyonrails.org/active_record_multiple_databases.html#migrate-to-the-new-connection-handling
 (called from <top (required)> at /Users/ysh-nh/develop/textae-configs/app/models/application_record.rb:1)
/Users/ysh-nh/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/activesupport-7.0.8/lib/active_support/testing/parallelization.rb:3: warning: drb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add drb to your Gemfile or gemspec to silence this warning.
Run options: --seed 33501

# Running:

E

Error:
ConfigsControllerTest#test_should_create_config:
ArgumentError: unknown keyword: :config
    test/controllers/configs_controller_test.rb:21:in `block (2 levels) in <class:ConfigsControllerTest>'
    test/controllers/configs_controller_test.rb:20:in `block in <class:ConfigsControllerTest>'


rails test test/controllers/configs_controller_test.rb:19

E

Error:
ConfigsControllerTest#test_should_get_edit:
ArgumentError: unknown keyword: :id
    test/controllers/configs_controller_test.rb:33:in `block in <class:ConfigsControllerTest>'


rails test test/controllers/configs_controller_test.rb:32

E

Error:
ConfigsControllerTest#test_should_destroy_config:
ArgumentError: unknown keyword: :id
    test/controllers/configs_controller_test.rb:44:in `block (2 levels) in <class:ConfigsControllerTest>'
    test/controllers/configs_controller_test.rb:43:in `block in <class:ConfigsControllerTest>'


rails test test/controllers/configs_controller_test.rb:42

E

Error:
ConfigsControllerTest#test_should_get_index:
Devise::MissingWarden: Devise could not find the `Warden::Proxy` instance on your request environment.
Make sure that your application is loading Devise and Warden as expected and that the `Warden::Manager` middleware is present in your middleware stack.
If you are seeing this on one of your tests, ensure that your tests are either executing the Rails middleware stack or that your tests are using the `Devise::Test::ControllerHelpers` module to inject the `request.env['warden']` object for you.
    app/controllers/configs_controller.rb:8:in `index'
    test/controllers/configs_controller_test.rb:9:in `block in <class:ConfigsControllerTest>'


rails test test/controllers/configs_controller_test.rb:8

E

Error:
ConfigsControllerTest#test_should_show_config:
ArgumentError: unknown keyword: :id
    test/controllers/configs_controller_test.rb:28:in `block in <class:ConfigsControllerTest>'


rails test test/controllers/configs_controller_test.rb:27

E

Error:
ConfigsControllerTest#test_should_get_new:
Devise::MissingWarden: Devise could not find the `Warden::Proxy` instance on your request environment.
Make sure that your application is loading Devise and Warden as expected and that the `Warden::Manager` middleware is present in your middleware stack.
If you are seeing this on one of your tests, ensure that your tests are either executing the Rails middleware stack or that your tests are using the `Devise::Test::ControllerHelpers` module to inject the `request.env['warden']` object for you.
    test/controllers/configs_controller_test.rb:15:in `block in <class:ConfigsControllerTest>'


rails test test/controllers/configs_controller_test.rb:14

E

Error:
ConfigsControllerTest#test_should_update_config:
ArgumentError: unknown keywords: :id, :config
    test/controllers/configs_controller_test.rb:38:in `block in <class:ConfigsControllerTest>'


rails test test/controllers/configs_controller_test.rb:37



Finished in 0.041703s, 167.8536 runs/s, 0.0000 assertions/s.
7 runs, 0 assertions, 0 failures, 7 errors, 0 skips
```

</details>