### PR TITLE
Remove spring gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,9 +46,6 @@ end
 group :development do
 	# Access an IRB console on exception pages or by using <%= console %> in views
 	gem 'web-console'
-
-	# Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-	gem 'spring'
 end
 
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,7 +258,6 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
-    spring (4.1.3)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -322,7 +321,6 @@ DEPENDENCIES
   rake
   sass-rails
   sdoc
-  spring
   sprockets-rails
   sqlite3
   uglifier


### PR DESCRIPTION
## 概要
spring gemによってtestにエラーが発生していました。
これをspring gemを削除することで対応しました。

## 作業内容
- spring gemの削除

これによって、rails testコマンドによって発生していたspringのエラーが解消しました。
```
➜  textae-configs git:(misc/remove_spring) ✗ rails test
DEPRECATION WARNING: Using legacy connection handling is deprecated. Please set
`legacy_connection_handling` to `false` in your application.

The new connection handling does not support `connection_handlers`
getter and setter.

Read more about how to migrate at: https://guides.rubyonrails.org/active_record_multiple_databases.html#migrate-to-the-new-connection-handling
 (called from <top (required)> at /Users/ysh-nh/develop/textae-configs/app/models/application_record.rb:1)
Run options: --seed 29417

# Running:

E

Error:
ConfigsControllerTest#test_should_get_edit:
ActiveRecord::RecordNotUnique: RuntimeError: UNIQUE constraint failed: configs.name
```