### PR TITLE
Add validation to is public

### DIFF
--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -6,6 +6,7 @@ class Config < ApplicationRecord
 
 	validates_format_of :name, :with => /\A[a-z0-9\-_]+\z/i
 	validates :body, presence: true
+	validates :is_public, boolean: true
 
 	scope :accessibles, -> (current_user) {
 		if current_user.present?

--- a/app/validators/boolean_validator.rb
+++ b/app/validators/boolean_validator.rb
@@ -1,6 +1,6 @@
 class BooleanValidator < ActiveModel::EachValidator
   def validate_each(record, attr, _value)
-    before_value = record.public_send("#{attr}_before_type_cast")
-    record.errors.add(attr, "must be true or false.") unless %w[true false 1 0].include?(before_value.to_s.downcase)
+    raw_value = record.public_send("#{attr}_before_type_cast")
+    record.errors.add(attr, "must be true or false.") unless %w[true false 1 0].include?(raw_value.to_s.downcase)
   end
 end

--- a/app/validators/boolean_validator.rb
+++ b/app/validators/boolean_validator.rb
@@ -1,0 +1,6 @@
+class BooleanValidator < ActiveModel::EachValidator
+  def validate_each(record, attr, _value)
+    before_value = record.send("#{attr}_before_type_cast")
+    record.errors.add(attr, "must be true or false.") unless %w[true false 1 0].include?(before_value.to_s.downcase)
+  end
+end

--- a/app/validators/boolean_validator.rb
+++ b/app/validators/boolean_validator.rb
@@ -1,5 +1,12 @@
-# BooleanValidator prevents unexpected Rails type conversion.
-# For example, it prevents the value like ‘foo’ or ‘bar’ from being saved as true.
+# In order to clarify the API specification, I would like to restrict the input values
+# to '1', 'true', '0', and 'false' for parameters that receive Boolean values.
+
+# However, when using Rails built-in validator, values like 'foo' and 'bar' are also accepted as true.
+# This is because Rails built-in validator checks the value after Rails type casting process.
+# In Rails' type casting, strings that are not false are converted to true.
+
+# The BooleanValidator checks the value before type casting, and prevents values like 'foo' and 'bar' from being saved as true.
+# Example of use: `validates :is_public, boolean: true`
 
 class BooleanValidator < ActiveModel::EachValidator
   VALID_VALUES = [

--- a/app/validators/boolean_validator.rb
+++ b/app/validators/boolean_validator.rb
@@ -1,6 +1,6 @@
 class BooleanValidator < ActiveModel::EachValidator
   def validate_each(record, attr, _value)
-    before_value = record.send("#{attr}_before_type_cast")
+    before_value = record.public_send("#{attr}_before_type_cast")
     record.errors.add(attr, "must be true or false.") unless %w[true false 1 0].include?(before_value.to_s.downcase)
   end
 end

--- a/app/validators/boolean_validator.rb
+++ b/app/validators/boolean_validator.rb
@@ -1,5 +1,5 @@
-# BooleanValidator prevents Rails type conversion from storing the true/false value as an unexpected value
-# when it is received as a string.
+# BooleanValidator prevents unexpected Rails type conversion.
+# For example, it prevents the value like ‘foo’ or ‘bar’ from being saved as true.
 
 class BooleanValidator < ActiveModel::EachValidator
   VALID_VALUES = [

--- a/app/validators/boolean_validator.rb
+++ b/app/validators/boolean_validator.rb
@@ -2,8 +2,13 @@
 # when it is received as a string.
 
 class BooleanValidator < ActiveModel::EachValidator
+  VALID_VALUES = [
+    "true", "1", 1,
+    "false", "0", 0
+  ].freeze
+
   def validate_each(record, attr, _value)
     raw_value = record.public_send("#{attr}_before_type_cast")
-    record.errors.add(attr, "must be true or false.") unless %w[true false 1 0].include?(raw_value.to_s.downcase)
+    record.errors.add(attr, "must be true or false.") unless VALID_VALUES.include?(raw_value)
   end
 end

--- a/app/validators/boolean_validator.rb
+++ b/app/validators/boolean_validator.rb
@@ -1,3 +1,6 @@
+# BooleanValidator prevents Rails type conversion from storing the true/false value as an unexpected value
+# when it is received as a string.
+
 class BooleanValidator < ActiveModel::EachValidator
   def validate_each(record, attr, _value)
     raw_value = record.public_send("#{attr}_before_type_cast")


### PR DESCRIPTION
## 概要
config APIではis_publicに好きなように値を指定できます。
Railsの暗黙的な型変換によって、予期せぬ型変換が起こってしまっていました。
この問題に対応しました。

## 作業内容
- カスタムバリデータの作成
- is_publicへのバリデーション追加

このPRのコミット
https://github.com/pubannotation/textae-configs/commit/087429c0800d51b347acaa3d286f79fdf5f52b32

今回の修正では以下の記事のコードをほぼ流用しています。
https://qiita.com/rf_p/items/db7f2cce3d0e314550a7
内容は理解し、副作用等の影響がないことも考え、問題ないと判断しました。
## 動作確認
### true/falseを指定した場合
バリデーションに通ります。
```
curl -X PUT http://localhost:3000/api/v1/configs/test3\?description\=updated\&is_public\=true
{"message":"Config test3 was successfully updated."}%

curl -X PUT http://localhost:3000/api/v1/configs/test3\?description\=updated\&is_public\=false
{"message":"Config test3 was successfully updated."}%
```

### true/false以外を指定した場合
バリデーションに引っ掛かります。
```
curl -X PUT http://localhost:3000/api/v1/configs/test3\?description\=updated\&is_public\=abc
{"error":"Validation failed: Is public must be true or false."}

curl -X PUT http://localhost:3000/api/v1/configs/test3\?description\=updated\&is_public\=nil
{"error":"Validation failed: Is public must be true or false."}
```

### 1/0を指定した場合
バリデーションに通ります。1はtrue, 0はfalseとして扱われます。
```
curl -X PUT http://localhost:3000/api/v1/configs/test3\?description\=updated\&is_public\=1
{"message":"Config test3 was successfully updated."}%

curl -X PUT http://localhost:3000/api/v1/configs/test3\?description\=updated\&is_public\=0
{"message":"Config test3 was successfully updated."}%
```
理由としては、true/falseのみを許可する場合、ブラウザでis_publicをチェックボックスで指定するケースに対応できなくなってしまうため、true/false/1/0を許可する形にしました。

画面ではチェックボックスのためバリデーションエラーが起こる可能性はありません。
APIではメッセージとして1/0も通ることを明示する必要はないと判断したため、「trueまたはfalseを指定して」というメッセージとしました。

最後に画面での動作に影響がないことを確認しました。