### PR TITLE
Fix json parse error

### DIFF
--- a/app/controllers/configs_controller.rb
+++ b/app/controllers/configs_controller.rb
@@ -88,30 +88,33 @@ class ConfigsController < ApplicationController
     end
 
     def get_body
-      if params.has_key?(:config) && params[:config].present?
-        _config = params.require(:config).permit(:name, :description, :body, :is_public)
-        if _config[:body].present?
-          begin
-            JSON.parse _config[:body]
-          rescue => e
-            flash.now[:notice] = e.message
-            nil
+      body_obj =
+        if params.has_key?(:config) && params[:config].present?
+          _config = params.require(:config).permit(:name, :description, :body, :is_public)
+          if _config[:body].present?
+            begin
+              JSON.parse _config[:body]
+            rescue => e
+              flash.now[:notice] = e.message
+              nil
+            end
+          else
+            {}
           end
+        elsif params.has_key?(:"entity types") || params.has_key?(:"relation types")
+          {
+            "autocompletion_ws": params.fetch(:"autocompletion_ws", ""),
+            "entity types": params.fetch(:"entity types", []),
+            "relation types": params.fetch(:"relation types", []),
+            "attribute types": params.fetch(:"attribute types", []),
+            "delimiter characters": params.fetch(:"delimiter characters", []),
+            "non-edge characters": params.fetch(:"non-edge characters", [])
+          }.keep_if{|k, v| v.present?}
         else
-          {}
+          nil
         end
-      elsif params.has_key?(:"entity types") || params.has_key?(:"relation types")
-        {
-          "autocompletion_ws": params.fetch(:"autocompletion_ws", ""),
-          "entity types": params.fetch(:"entity types", []),
-          "relation types": params.fetch(:"relation types", []),
-          "attribute types": params.fetch(:"attribute types", []),
-          "delimiter characters": params.fetch(:"delimiter characters", []),
-          "non-edge characters": params.fetch(:"non-edge characters", [])
-        }.keep_if{|k, v| v.present?}
-      else
-        nil
-      end
+
+      body_obj.nil? ? nil : JSON.generate(body_obj)
     end
 
     def get_config


### PR DESCRIPTION
## 概要
画面からconfigを作成/更新時にJSON::ParseErrorが発生する問題がありました。

通常のConfigsControllerで、bodyパラメータに対してJSON.generateせずに保存する形になっていたため、`{"abc" => "def" }`のような形式で保存され、表示時にエラーになっていました。

原因はJSON保存形式変更時のコミットです。
https://github.com/pubannotation/textae-configs/pull/15/commits/842d95b60dc9635aaf8dbaf76442d3dae1efa0b0#diff-9be165eaf6ab94041c64210f4d2a69dbb1d2f7320066a7a000b8912ea3df814dL89-L115
最初にコールバックを用いた形式で変更し、その後にコールバックを使わない方法に切り替えました。
コールバックを使わない方法に切り替え時に、コールバックを用いる変更の一部をもとに戻し忘れたため発生していました。

これを戻す修正を行いました。

このPRのコミット: https://github.com/pubannotation/textae-configs/pull/26/commits/20c6ba2d5329a7a63135227bb0a7bea43c107afb

## 動作確認
### config作成ができる
|<img width="472" alt="image" src="https://github.com/user-attachments/assets/345ee08f-9b63-4979-a72a-237d211c5e64">|
|:-|

### テストが通る
```
# Running:

.................

Finished in 0.124447s, 136.6043 runs/s, 297.3153 assertions/s.
17 runs, 37 assertions, 0 failures, 0 errors, 0 skips
```