### PR TITLE
Fix active_storage error

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,18 @@
 require_relative "boot"
 
-require "rails/all"
+require "rails"
+# Pick the frameworks you want:
+require "active_model/railtie"
+require "active_job/railtie"
+require "active_record/railtie"
+# require "active_storage/engine"
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "action_mailbox/engine"
+require "action_text/engine"
+require "action_view/railtie"
+require "action_cable/engine"
+require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.cache_store = :memory_store
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  # config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
   # config.asset_host = "http://assets.example.com"
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  # config.active_storage.service = :local
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # config.assume_ssl = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.action_controller.allow_forgery_protection = false
 
   # Store uploaded files on the local file system in a temporary directory.
-  config.active_storage.service = :test
+  # config.active_storage.service = :test
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the


### PR DESCRIPTION
## 概要
production環境でサーバーを立ち上げる際にActiveStorage関係のエラーが発生していました。
`Couldn't find Active Storage configuration in /Users/ysh-nh/develop/textae-configs/config/storage.yml`

このエラーを解決し、サーバーを起動できるように修正しました。

## 修正内容
- config/application.rbでrequire "rails/all"から、railsの機能を1つづつrequireする形に変更
- config/environmentsの各環境ファイルで、active_storageのconfig設定をコメントアウト

## 動作確認
### サーバー起動
```
rails s -e production
=> Booting Puma
=> Rails 8.0.1 application starting in production
=> Run `bin/rails server --help` for more startup options
Puma starting in single mode...
* Puma version: 6.5.0 ("Sky's Version")
* Ruby version: ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
*  Min threads: 3
*  Max threads: 3
*  Environment: production
*          PID: 98907
* Listening on http://0.0.0.0:3000
Use Ctrl-C to stop
```

### テスト
直近で追加したテストは通っています。
```
rails test
Run options: --seed 59149

# Running:

E

Error:
ConfigsControllerTest#test_should_get_index:
Devise::MissingWarden: Devise could not find the `Warden::Proxy` instance on your request environment.
Make sure that your application is loading Devise and Warden as expected and that the `Warden::Manager` middleware is present in your middleware stack.
If you are seeing this on one of your tests, ensure that your tests are either executing the Rails middleware stack or that your tests are using the `Devise::Test::ControllerHelpers` module to inject the `request.env['warden']` object for you.
    app/controllers/configs_controller.rb:8:in 'ConfigsController#index'
    test/controllers/configs_controller_test.rb:9:in 'block in <class:ConfigsControllerTest>'


bin/rails test test/controllers/configs_controller_test.rb:8

E

Error:
ConfigsControllerTest#test_should_show_config:
ArgumentError: unknown keyword: :id
    test/controllers/configs_controller_test.rb:28:in 'block in <class:ConfigsControllerTest>'


bin/rails test test/controllers/configs_controller_test.rb:27

E

Error:
ConfigsControllerTest#test_should_update_config:
ArgumentError: unknown keywords: :id, :config
    test/controllers/configs_controller_test.rb:38:in 'block in <class:ConfigsControllerTest>'


bin/rails test test/controllers/configs_controller_test.rb:37

E

Error:
ConfigsControllerTest#test_should_create_config:
ArgumentError: unknown keyword: :config
    test/controllers/configs_controller_test.rb:21:in 'block (2 levels) in <class:ConfigsControllerTest>'
    test/controllers/configs_controller_test.rb:20:in 'block in <class:ConfigsControllerTest>'


bin/rails test test/controllers/configs_controller_test.rb:19

E

Error:
ConfigsControllerTest#test_should_destroy_config:
ArgumentError: unknown keyword: :id
    test/controllers/configs_controller_test.rb:44:in 'block (2 levels) in <class:ConfigsControllerTest>'
    test/controllers/configs_controller_test.rb:43:in 'block in <class:ConfigsControllerTest>'


bin/rails test test/controllers/configs_controller_test.rb:42

E

Error:
ConfigsControllerTest#test_should_get_new:
Devise::MissingWarden: Devise could not find the `Warden::Proxy` instance on your request environment.
Make sure that your application is loading Devise and Warden as expected and that the `Warden::Manager` middleware is present in your middleware stack.
If you are seeing this on one of your tests, ensure that your tests are either executing the Rails middleware stack or that your tests are using the `Devise::Test::ControllerHelpers` module to inject the `request.env['warden']` object for you.
    test/controllers/configs_controller_test.rb:15:in 'block in <class:ConfigsControllerTest>'


bin/rails test test/controllers/configs_controller_test.rb:14

E

Error:
ConfigsControllerTest#test_should_get_edit:
ArgumentError: unknown keyword: :id
    test/controllers/configs_controller_test.rb:33:in 'block in <class:ConfigsControllerTest>'


bin/rails test test/controllers/configs_controller_test.rb:32

/Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
/Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
../Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
../Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
../Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
../Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
..

Finished in 0.147916s, 162.2543 runs/s, 263.6632 assertions/s.
24 runs, 39 assertions, 0 failures, 7 errors, 0 skips
```