### PR TITLE
Remove unnecessary Rails components

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,10 +8,10 @@ require "active_record/railtie"
 # require "active_storage/engine"
 require "action_controller/railtie"
 require "action_mailer/railtie"
-require "action_mailbox/engine"
-require "action_text/engine"
+# require "action_mailbox/engine"
+# require "action_text/engine"
 require "action_view/railtie"
-require "action_cable/engine"
+# require "action_cable/engine"
 require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems


### PR DESCRIPTION
## 概要
使用していないRailsの機能をrequireしないように変更しました。

コメントアウトした機能
- Action Cable
- Action Text
- Action Mailbox

## 動作確認
### サーバー起動
```
rails s
=> Booting Puma
=> Rails 8.0.1 application starting in development
=> Run `bin/rails server --help` for more startup options
Puma starting in single mode...
* Puma version: 6.5.0 ("Sky's Version")
* Ruby version: ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
*  Min threads: 3
*  Max threads: 3
*  Environment: development
*          PID: 94237
* Listening on http://127.0.0.1:3000
* Listening on http://[::1]:3000
Use Ctrl-C to stop
```

### 手動テスト
以下について手動で確認し、動作問題ありませんでした。
- config作成
- ログインログアウト
- サインアップ
- その他ページ遷移

### テスト
修正前と同じ結果です。
```
➜  textae-configs git:(refactor/remove_unused_rails_function) ✗ rails test
Run options: --seed 53603

# Running:

E

Error:
ConfigsControllerTest#test_should_create_config:
ArgumentError: unknown keyword: :config
    test/controllers/configs_controller_test.rb:21:in 'block (2 levels) in <class:ConfigsControllerTest>'
    test/controllers/configs_controller_test.rb:20:in 'block in <class:ConfigsControllerTest>'


bin/rails test test/controllers/configs_controller_test.rb:19

E

Error:
ConfigsControllerTest#test_should_get_new:
Devise::MissingWarden: Devise could not find the `Warden::Proxy` instance on your request environment.
Make sure that your application is loading Devise and Warden as expected and that the `Warden::Manager` middleware is present in your middleware stack.
If you are seeing this on one of your tests, ensure that your tests are either executing the Rails middleware stack or that your tests are using the `Devise::Test::ControllerHelpers` module to inject the `request.env['warden']` object for you.
    test/controllers/configs_controller_test.rb:15:in 'block in <class:ConfigsControllerTest>'


bin/rails test test/controllers/configs_controller_test.rb:14

E

Error:
ConfigsControllerTest#test_should_get_index:
Devise::MissingWarden: Devise could not find the `Warden::Proxy` instance on your request environment.
Make sure that your application is loading Devise and Warden as expected and that the `Warden::Manager` middleware is present in your middleware stack.
If you are seeing this on one of your tests, ensure that your tests are either executing the Rails middleware stack or that your tests are using the `Devise::Test::ControllerHelpers` module to inject the `request.env['warden']` object for you.
    app/controllers/configs_controller.rb:8:in 'ConfigsController#index'
    test/controllers/configs_controller_test.rb:9:in 'block in <class:ConfigsControllerTest>'


bin/rails test test/controllers/configs_controller_test.rb:8

E

Error:
ConfigsControllerTest#test_should_get_edit:
ArgumentError: unknown keyword: :id
    test/controllers/configs_controller_test.rb:33:in 'block in <class:ConfigsControllerTest>'


bin/rails test test/controllers/configs_controller_test.rb:32

E

Error:
ConfigsControllerTest#test_should_destroy_config:
ArgumentError: unknown keyword: :id
    test/controllers/configs_controller_test.rb:44:in 'block (2 levels) in <class:ConfigsControllerTest>'
    test/controllers/configs_controller_test.rb:43:in 'block in <class:ConfigsControllerTest>'


bin/rails test test/controllers/configs_controller_test.rb:42

E

Error:
ConfigsControllerTest#test_should_show_config:
ArgumentError: unknown keyword: :id
    test/controllers/configs_controller_test.rb:28:in 'block in <class:ConfigsControllerTest>'


bin/rails test test/controllers/configs_controller_test.rb:27

E

Error:
ConfigsControllerTest#test_should_update_config:
ArgumentError: unknown keywords: :id, :config
    test/controllers/configs_controller_test.rb:38:in 'block in <class:ConfigsControllerTest>'


bin/rails test test/controllers/configs_controller_test.rb:37

/Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
..../Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
../Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
/Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
../Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.10/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
.

Finished in 0.210150s, 114.2041 runs/s, 185.5817 assertions/s.
24 runs, 39 assertions, 0 failures, 7 errors, 0 skips
```