### PR TITLE
Fix old failing tests

### DIFF
--- a/test/controllers/configs_controller_test.rb
+++ b/test/controllers/configs_controller_test.rb
@@ -1,14 +1,17 @@
 require 'test_helper'
 
 class ConfigsControllerTest < ActionController::TestCase
+  include Devise::Test::ControllerHelpers
+
   setup do
     @config = configs(:one)
+    @user = users(:one)
+    sign_in @user
   end
 
   test "should get index" do
     get :index
     assert_response :success
-    assert_not_nil assigns(:configs)
   end
 
   test "should get new" do
@@ -18,30 +21,48 @@ class ConfigsControllerTest < ActionController::TestCase
 
   test "should create config" do
     assert_difference('Config.count') do
-      post :create, config: { body: @config.body, description: @config.description, is_public: @config.is_public, name: @config.name }
+      post :create, params: {
+                      config: {
+                        body: @config.body,
+                        description: @config.description,
+                        is_public: @config.is_public,
+                        name: "new-config"
+                      }
+                    }
     end
 
-    assert_redirected_to config_path(assigns(:config))
+    created_config = Config.find_by(name: "new-config")
+    assert_redirected_to config_path(created_config)
   end
 
   test "should show config" do
-    get :show, id: @config
+    get :show, params: { id: @config.id }
     assert_response :success
   end
 
   test "should get edit" do
-    get :edit, id: @config
+    get :edit, params: { id: @config.id }
     assert_response :success
   end
 
   test "should update config" do
-    patch :update, id: @config, config: { body: @config.body, description: @config.description, is_public: @config.is_public, name: @config.name }
-    assert_redirected_to config_path(assigns(:config))
+    patch :update, params: {
+                    id: @config.id,
+                    config: {
+                      body: @config.body,
+                      description: @config.description,
+                      is_public: @config.is_public,
+                      name: @config.name
+                    }
+                  }
+
+    updated_config = Config.find(@config.id)
+    assert_redirected_to config_path(updated_config)
   end
 
   test "should destroy config" do
     assert_difference('Config.count', -1) do
-      delete :destroy, id: @config
+      delete :destroy, params: { id: @config.id }
     end
 
     assert_redirected_to configs_path

--- a/test/fixtures/configs.yml
+++ b/test/fixtures/configs.yml
@@ -3,8 +3,9 @@
 one:
   name: MyString
   description: MyText
-  body: MyText
+  body: '{}'
   is_public: false
+  user_id: 1
 
 two:
   name: test-config-1


### PR DESCRIPTION
## 概要
ConfigsControllerのテストはおそらくアプリ作成時に自動生成されたコードで、現在はテスト記法の変更やtextae-configの仕様変更によりテストが通らない状態になっていました。
これを正しくテストされるように修正しました。

## 作業内容
- ログイン機能に対応していなかったため対応
- 古いリクエストメソッドの記法を修正
  - `post :create, config: xxx` => `post :create, params: config: xxx`
- assignsメソッドを使わないように修正
  - assignsメソッドは非推奨になっていて、minitest標準ではなくgemに分離されている
  - assignsで行っていた検証を省略、または同じような意味のコードに置き換え

## テスト結果
テストが通るようになりました。
(warningが気になりますが、rack gemのwarningなので問題ないです)

```
➜  textae-configs git:(fix/rewrite_old_failing_tests) ✗ rails test
Run options: --seed 49628

# Running:

......./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
../Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
/Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
.../Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
.../Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
./Users/ysh-nh/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rack-3.1.12/lib/rack/mock_request.rb:148: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
.

Finished in 0.377552s, 63.5674 runs/s, 140.3780 assertions/s.
24 runs, 53 assertions, 0 failures, 0 errors, 0 skips
```